### PR TITLE
fix: don’t perform SPA-style navigation if any of the modifier keys are used

### DIFF
--- a/src/react/components/Link.tsx
+++ b/src/react/components/Link.tsx
@@ -36,11 +36,17 @@ export const Link = <Match,>({
     <a
       href={href}
       onClick={(e) => {
-        e.preventDefault();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (navigate as any)(route, match);
+        if (!isModifiedEvent(e)) {
+          e.preventDefault();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (navigate as any)(route, match);
+        }
       }}
       {...props}
     />
   );
 };
+
+function isModifiedEvent(event: React.MouseEvent) {
+  return event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+}


### PR DESCRIPTION
Browsers have special behaviors for modifier keys by default. If the user uses any of the modifier keys, we should prioritize the default behavior.