### PR TITLE
fix: PathRouteBuilder#any discards their exactRoute

### DIFF
--- a/src/builder/PathRouteBuilder/PathRouteBuilder.test.ts
+++ b/src/builder/PathRouteBuilder/PathRouteBuilder.test.ts
@@ -227,6 +227,16 @@ describe("PathRouteBuilder", () => {
       });
       expect(res.exactRoute.action({})).toBe("I am root");
     });
+    it("root works with any route", () => {
+      const res = PathRouteBuilder.init()
+        .exact({
+          action: () => "I am root",
+        })
+        .any("id", {
+          action: ({ id }) => `id is ${id.slice(0, 8)}`,
+        });
+      expect(res.exactRoute.action({})).toBe("I am root");
+    })
     describe("resolve", () => {
       it("resolve root", () => {
         const toplevel = PathRouteBuilder.init()

--- a/src/builder/PathRouteBuilder/index.ts
+++ b/src/builder/PathRouteBuilder/index.ts
@@ -289,6 +289,7 @@ export class PathRouteBuilder<
         routeDefinition?.action
       ),
     };
+    result.#exactRoute = this.#exactRoute
     return result;
   }
 


### PR DESCRIPTION
Consider the following code,

```ts
import { Path } from "rocon/react";

const anyThenExactRoutes = Path()
  .any("id", {
    action: ({ id }) => `id is ${id.slice(0, 8)}`,
  })
  .exact({
    action: () => "I am root",
  });

const exactThenAnyRoutes = Path()
  .exact({
    action: () => "I am root",
  })
  .any("id", {
    action: ({ id }) => `id is ${id.slice(0, 8)}`,
  });

console.log(`any then exact: ${anyThenExactRoutes.exactRoute}
exact then any: ${exactThenAnyRoutes.exactRoute}`);
```

both `anyThenExactRoutes` and `exactThenAnyRoutes` have an `exactRoute` property on the type level, but...

Expected behavior
--

```
any then exact: [Object object]
exact then any: [Object object]
```

Actual behavior
--

```
any then exact: [Object object]
exact then any: undefined
```
