### PR TITLE
Fix history dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.2.8",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.15.4"
+        "@babel/runtime": "^7.15.4",
+        "history": "^5.3.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.15.4",
@@ -32,7 +33,6 @@
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
-        "history": "^5.3.0",
         "husky": "^7.0.0",
         "jest": "^27.1.0",
         "lint-staged": "^11.1.2",
@@ -42,9 +42,6 @@
         "react-dom": "^18.1.0",
         "standard-version": "^9.3.1",
         "typescript": "^4.4.2"
-      },
-      "peerDependencies": {
-        "history": "^5.0.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -9135,7 +9132,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -23912,7 +23908,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.7.6"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "history": "^5.3.0",
     "husky": "^7.0.0",
     "jest": "^27.1.0",
     "lint-staged": "^11.1.2",
@@ -80,9 +79,7 @@
     }
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4"
-  },
-  "peerDependencies": {
-    "history": "^5.0.0"
+    "@babel/runtime": "^7.15.4",
+    "history": "^5.3.0"
   }
 }


### PR DESCRIPTION
### Overview

Fix https://github.com/uhyo/rocon/issues/6 properly.

### Description

Current dependency settings about `history` package are probably wrong.
`history` should be included in `dependencies`, not `devDependencies` and `peerDependencies`.
[RoconRoot](https://github.com/uhyo/rocon/blob/v1.1.1/src/react/components/RoconRoot.tsx) using `history` means that `history` is required by rocon's production code (not only development code).

I think users don't wanna install `history` with rocon manually.
With this fix, users will only need to install rocon as follows:

```sh
npm install rocon
```