### PR TITLE
fix: given onClick callback was override default navigation handler

### DIFF
--- a/src/react/components/Link.tsx
+++ b/src/react/components/Link.tsx
@@ -21,7 +21,7 @@ export type LinkPropsWithRef<Match> = LinkProps<Match> & {
  * Renders an <a> element to given route.
  */
 const RawLink = <Match,>(
-  { route, match, ...props }: LinkProps<Match>,
+  { route, match, onClick, ...props }: LinkProps<Match>,
   ref: Ref<HTMLAnchorElement | null>
 ): ReactElement | null => {
   const parentRoute = useContext(RouteContext);
@@ -40,6 +40,9 @@ const RawLink = <Match,>(
       ref={ref}
       href={href}
       onClick={(e) => {
+        if (onClick) {
+          onClick(e);
+        }
         if (!isModifiedEvent(e)) {
           e.preventDefault();
           // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Issue

```typescript
// src/react/components/Link.tsx

onClick={(e) => {
  /* ... */
}
{...props}  // <- override the Rocon's onClick if "onClick" was applied
```

## Now

Given onClick handler will work with Rocon's one.